### PR TITLE
preview-size: global option for agda_preview_line_number

### DIFF
--- a/autoload/agda.vim
+++ b/autoload/agda.vim
@@ -369,11 +369,13 @@ function s:pretty_goal_info(goal_info)
 endfunction
 
 function s:show_preview(lines)
+  let l:line_limit = get(g:, 'agda_preview_line_number', 7)
+
   silent! belowright noswapfile pedit! \*All\ Goals\*
   wincmd P
   setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no modifiable
   call setline(1, a:lines)
   setlocal nomodified nomodifiable
-  resize 7
+  exec "resize " . l:line_limit
   wincmd p
 endfunction


### PR DESCRIPTION
By setting `g:agda_preview_line_number` a user can change the default(7) number of lines in preview.

I am not sure that the `exec "resize " . l:line_limit` is the best way to handle it, but I could not come up with different working solution.
I am happy to change this code in any way as long as it can be configured.